### PR TITLE
Restore edit mode support

### DIFF
--- a/simulador.php
+++ b/simulador.php
@@ -7,6 +7,10 @@
         <script src="system/svg.js"></script>
         <script src="system/Init.js"></script>
         <script src="processor/<?php echo $_GET['simulador'] ?>/cfg.js"></script>
+        <?php if(isset($_GET['edit_mode'])){ ?>
+          <script src="system/edit_mode.js"></script>
+        <?php } ?>
+
         <header class="header">
             <?php include 'includes/menu.php' ?>
         </header>
@@ -40,6 +44,11 @@
                             <!-- <button title="" type="button" onclick="editor_assembly();" title="editor"><\></button> -->
                             <button type="button" id="configPanel" title="Painel de configuração"><i class="fa fa-cog"></i></button>
                             <!-- <button type="button" id="description" title="Descritivo"><i class="fa fa-file-text-o"></i></button> -->
+                            <?php if(isset($_GET['edit_mode'])){ ?>
+                              <button type="button" title="Edit" onClick="design_mode()"><i class="fa fa-edit"></i></button>
+                              <button type="button" title="Save"onClick="design_mode_end()"><i class="fa fa-save"></i></button>
+                            <?php } ?>
+
                         </div>
                     </div>
                 </div>

--- a/system/edit_mode.js
+++ b/system/edit_mode.js
@@ -1,0 +1,24 @@
+function design_mode() {
+  $('.draggable').draggable({
+    containment: "#processador",
+    scroll: false,
+    grid: [20, 20],
+  });
+}
+
+function design_mode_end() {
+  let positions = {};
+  $('.draggable').each(function() {
+    var offset = $(this).position();
+    positions[$(this).attr('el')] = {
+      left: Math.ceil(offset.left),
+      top: Math.ceil(offset.top)
+    };
+    $(this).draggable("destroy").attr('l', (Math.ceil(offset.left)));
+  });
+
+  $(window).resize();
+
+  console.log(positions);
+  alert(JSON.stringify(positions));
+}


### PR DESCRIPTION
#### Description
This PR adds support for:
- Graphical drag and drop of `registers`, `functionUnities` and `auxRegisters`.
- Add the buttons to start and export the positions
- Querystring parameter to display the feature `edit_mode=true`
  - ex: `http://http://localhost:3000/simulador.php?simulador=sergium&edit_mode=true`

Note:
- The set of positions will be printed with an `alert` and on the browser console 


#### Screenshots

New buttons
![image](https://user-images.githubusercontent.com/1142822/80288501-cb666a00-870e-11ea-8a90-6f955e32da11.png)

Alert box
![2020-04-25-160726_808x210_scrot](https://user-images.githubusercontent.com/1142822/80288517-e0db9400-870e-11ea-8273-e63272c0829a.png)

Console content
![2020-04-25-160757_644x391_scrot](https://user-images.githubusercontent.com/1142822/80288535-f51f9100-870e-11ea-8b00-9dca10d81dc6.png)

